### PR TITLE
Recruiter statistics implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 php:
   - 5.6
-
+env:
+  - TEST_DUMP=1
 install: 
   - phpenv config-add phpconfig.ini
   - composer install

--- a/spec/Recruiter/Acceptance/BaseAcceptanceTest.php
+++ b/spec/Recruiter/Acceptance/BaseAcceptanceTest.php
@@ -17,11 +17,26 @@ abstract class BaseAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->roster = $this->recruiterDb->selectCollection('roster');
         $this->recruiter = new Recruiter($this->recruiterDb);
         $this->jobs = 0;
+        $this->processRecruiter = null;
+        $this->processWorkers = [];
     }
 
-    public function cleanDb()
+    public function tearDown()
+    {
+        $this->terminateProcesses(SIGKILL);
+    }
+
+    protected function cleanDb()
     {
         $this->recruiterDb->drop();
+    }
+
+    protected function clean()
+    {
+        $this->terminateProcesses(SIGKILL);
+        $this->cleanLogs();
+        $this->cleanDb();
+        $this->jobs = 0;
     }
 
     public function cleanLogs()
@@ -103,6 +118,51 @@ abstract class BaseAcceptanceTest extends \PHPUnit_Framework_TestCase
             ->inBackground()
             ->execute();
         $this->jobs++;
+    }
+
+    protected function start($workers)
+    {
+        $this->processRecruiter = $this->startRecruiter();
+        $this->processWorkers = [];
+        for ($i = 0; $i < $workers; $i++) {
+            $this->processWorkers[$i] = $this->startWorker();
+        }
+    }
+
+    private function terminateProcesses($signal)
+    {
+        if ($this->processRecruiter) {
+            $this->stopProcessWithSignal($this->processRecruiter, $signal);
+            $this->processRecruiter = null;
+        }
+        foreach ($this->processWorkers as $processWorker) {
+            $this->stopProcessWithSignal($processWorker, $signal);
+        }
+        $this->processWorkers = [];
+    }
+
+    protected function restartWorkerGracefully($workerIndex)
+    {
+        $this->stopProcessWithSignal($this->processWorkers[$workerIndex], SIGTERM);
+        $this->processWorkers[$workerIndex] = $this->startWorker();
+    }
+
+    protected function restartWorkerByKilling($workerIndex)
+    {
+        $this->stopProcessWithSignal($this->processWorkers[$workerIndex], SIGKILL);
+        $this->processWorkers[$workerIndex] = $this->startWorker();
+    }
+
+    protected function restartRecruiterGracefully()
+    {
+        $this->stopProcessWithSignal($this->processRecruiter, SIGTERM);
+        $this->processRecruiter = $this->startRecruiter();
+    }
+
+    protected function restartRecruiterByKilling()
+    {
+        $this->stopProcessWithSignal($this->processRecruiter, SIGKILL);
+        $this->processRecruiter = $this->startRecruiter();
     }
 
 }

--- a/spec/Recruiter/Acceptance/BaseAcceptanceTest.php
+++ b/spec/Recruiter/Acceptance/BaseAcceptanceTest.php
@@ -165,4 +165,17 @@ abstract class BaseAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->processRecruiter = $this->startRecruiter();
     }
 
+    protected function files()
+    {
+        $logs = '';
+        if (getenv('TEST_DUMP')) {
+            foreach ($this->files as $file) {
+                $logs .= $file. ":". PHP_EOL;
+                $logs .= file_get_contents($file);
+            }
+        } else {
+            $logs .= var_export($this->files, true);
+        }
+        return $logs;
+    }
 }

--- a/spec/Recruiter/Acceptance/BaseAcceptanceTest.php
+++ b/spec/Recruiter/Acceptance/BaseAcceptanceTest.php
@@ -110,11 +110,12 @@ abstract class BaseAcceptanceTest extends \PHPUnit_Framework_TestCase
     /**
      * @param integer $duration  milliseconds
      */
-    protected function enqueueJob($duration = 10)
+    protected function enqueueJob($duration = 10, $tag = 'generic')
     {
         $workable = ShellCommand::fromCommandLine("sleep " . ($duration / 1000));
         $workable
             ->asJobOf($this->recruiter)
+            ->taggedAs($tag)
             ->inBackground()
             ->execute();
         $this->jobs++;

--- a/spec/Recruiter/Acceptance/EnduranceTest.php
+++ b/spec/Recruiter/Acceptance/EnduranceTest.php
@@ -26,7 +26,7 @@ class EnduranceTest extends BaseAcceptanceTest
     public function testNotWithstandingCrashesJobsAreEventuallyPerformed()
     {
         $this
-            ->limitTo(20)
+            ->limitTo(100)
             ->forAll(
                 Generator\bind(
                     Generator\choose(1, 4),

--- a/spec/Recruiter/Acceptance/EnduranceTest.php
+++ b/spec/Recruiter/Acceptance/EnduranceTest.php
@@ -89,7 +89,7 @@ class EnduranceTest extends BaseAcceptanceTest
                 Timeout::inSeconds(
                     $estimatedTime,
                     function() {
-                        return "all $this->jobs jobs to be performed. Now is " . date('c') . " See: " . var_export($this->files, true);
+                        return "all $this->jobs jobs to be performed. Now is " . date('c') . " Logs: " . $this->files();
                     }
                 )
                     ->until(function() {

--- a/spec/Recruiter/Acceptance/EnduranceTest.php
+++ b/spec/Recruiter/Acceptance/EnduranceTest.php
@@ -7,6 +7,7 @@ use Eris;
 use Eris\Generator;
 use Eris\Generator\ConstantGenerator;
 use Eris\Listener;
+use Timeless as T;
 
 /**
  * @group long
@@ -100,12 +101,14 @@ class EnduranceTest extends BaseAcceptanceTest
                         return $this->jobRepository->countArchived() === $this->jobs;
                     });
 
-                $statistics = $this->recruiter->statistics();
+                $at = T\now();
+                $statistics = $this->recruiter->statistics($tag = null, $at);
                 $this->assertInvariantsOnStatistics($statistics);
                 // TODO: remove duplication
                 $statisticsByTag = [];
+                $cumulativeThroughput = 0;
                 foreach (['generic', 'fast-lane'] as $tag) {
-                    $statisticsByTag[$tag] = $this->recruiter->statistics($tag);
+                    $statisticsByTag[$tag] = $this->recruiter->statistics($tag, $at);
                     $this->assertInvariantsOnStatistics($statisticsByTag[$tag]);
                     $cumulativeThroughput += $statisticsByTag[$tag]['throughput']['value'];
                 }

--- a/spec/Recruiter/Job/RepositoryTest.php
+++ b/spec/Recruiter/Job/RepositoryTest.php
@@ -17,8 +17,12 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
 
     public function testQueued()
     {
-        $this->aJob()->inBackground()->execute();
-        $this->assertEquals(1, $this->repository->queued());
+        $this->aJob()->taggedAs('generic')->inBackground()->execute();
+        $this->aJob()->taggedAs('generic')->inBackground()->execute();
+        $this->aJob()->taggedAs('fast-lane')->inBackground()->execute();
+        $this->assertEquals(3, $this->repository->queued());
+        $this->assertEquals(2, $this->repository->queued('generic'));
+        $this->assertEquals(1, $this->repository->queued('fast-lane'));
     }
 
     private function aJob()

--- a/spec/Recruiter/Job/RepositoryTest.php
+++ b/spec/Recruiter/Job/RepositoryTest.php
@@ -40,6 +40,9 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
                 'latency' => [
                     'average' => 5,
                 ],
+                'execution_time' => [
+                    'average' => 0,
+                ],
             ],
             $this->repository->recentHistory()
         );

--- a/spec/Recruiter/Job/RepositoryTest.php
+++ b/spec/Recruiter/Job/RepositoryTest.php
@@ -14,6 +14,12 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->recruiterDb = (new MongoClient('localhost:27017'))->selectDB('recruiter');
         $this->recruiterDb->drop();
         $this->repository = new Repository($this->recruiterDb);
+        T\clock()->stop();
+    }
+
+    public function tearDown()
+    {
+        T\clock()->start();
     }
 
     public function testCountsQueuedJobsAsOfNow()
@@ -31,17 +37,17 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->repository->archive($this->aJob()->beforeExecution()->afterExecution(42));
         $this->repository->archive($this->aJob()->beforeExecution()->afterExecution(42));
         $this->repository->archive($this->aJob()->beforeExecution()->afterExecution(42));
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'throughput' => [
-                    'value' => 3,
+                    'value' => 3.0,
                     'value_per_second' => 3/60.0,
                 ],
                 'latency' => [
-                    'average' => 5,
+                    'average' => 5.0,
                 ],
                 'execution_time' => [
-                    'average' => 0,
+                    'average' => 0.0,
                 ],
             ],
             $this->repository->recentHistory()

--- a/spec/Recruiter/Job/RepositoryTest.php
+++ b/spec/Recruiter/Job/RepositoryTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Recruiter\Job;
+
+use Recruiter\Job;
+use Recruiter\JobToSchedule;
+use MongoClient;
+use DateTime;
+
+class RepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->recruiterDb = (new MongoClient('localhost:27017'))->selectDB('recruiter');
+        $this->recruiterDb->drop();
+        $this->repository = new Repository($this->recruiterDb);
+    }
+
+    public function testQueued()
+    {
+        $this->aJob()->inBackground()->execute();
+        $this->assertEquals(1, $this->repository->queued());
+    }
+
+    private function aJob()
+    {
+        $workable = $this
+            ->getMockBuilder('Recruiter\Workable')
+            ->getMock();
+
+        return new JobToSchedule(Job::around($workable, $this->repository));
+    }
+}

--- a/spec/Timeless/MongoDateTest.php
+++ b/spec/Timeless/MongoDateTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace Timeless;
 
-use Eris\TestTrait;
+use Eris;
 use Eris\Generator;
 
 class MongoDateTest extends \PHPUnit_Framework_TestCase
 {
-    use TestTrait;
+    use Eris\TestTrait;
 
     public function testConvertsBackAndForthMongoDatesWithoutLosingMillisecondPrecision()
     {

--- a/spec/Timeless/MongoDateTest.php
+++ b/spec/Timeless/MongoDateTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Timeless;
+
+use Eris\TestTrait;
+use Eris\Generator;
+
+class MongoDateTest extends \PHPUnit_Framework_TestCase
+{
+    use TestTrait;
+
+    public function testConvertsBackAndForthMongoDatesWithoutLosingMillisecondPrecision()
+    {
+        $this
+            ->forAll(
+                Generator\choose(0, 1500 * 1000 * 1000)
+            )
+            ->then(function($milliseconds) {
+                $moment = new Moment($milliseconds);
+                $this->assertEquals(
+                    $moment,
+                    MongoDate::toMoment(MongoDate::from($moment))
+                );
+            });
+    }
+}

--- a/src/Recruiter/Job.php
+++ b/src/Recruiter/Job.php
@@ -133,13 +133,15 @@ class Job
         }
     }
 
-    private function afterExecution($result)
+    public function afterExecution($result)
     {
         $this->status['done'] = true;
+        $this->status['executed_at'] = T\MongoDate::now();
         $this->lastJobExecution->completedWith($result);
         if ($this->hasBeenScheduled()) {
             $this->archive('done');
         }
+        return $this;
     }
 
     private function afterFailure($exception)

--- a/src/Recruiter/Job/Repository.php
+++ b/src/Recruiter/Job/Repository.php
@@ -6,6 +6,7 @@ use MongoDB;
 use MongoCollection;
 use Recruiter\Recruiter;
 use Recruiter\Job;
+use Timeless as T;
 
 class Repository
 {
@@ -68,6 +69,13 @@ class Repository
     public function countArchived()
     {
         return $this->archived->count();
+    }
+
+    public function queued()
+    {
+        return $this->scheduled->count([
+            'scheduled_at' => ['$lte' => T\MongoDate::now()],
+        ]);
     }
 
     private function map($cursor)

--- a/src/Recruiter/Job/Repository.php
+++ b/src/Recruiter/Job/Repository.php
@@ -93,14 +93,21 @@ class Repository
         ];
         $document = $this->archived->aggregate([
             ['$match' => $lastMinute],
-            ['$project' => ['latency' => ['$subtract' => [
-                '$last_execution.started_at',
-                '$last_execution.scheduled_at',
-            ]]]],
+            ['$project' => [
+                'latency' => ['$subtract' => [
+                    '$last_execution.started_at',
+                    '$last_execution.scheduled_at',
+                ]],
+                'execution_time' => ['$subtract' => [
+                    '$last_execution.ended_at',
+                    '$last_execution.started_at',
+                ]],
+            ]],
             ['$group' => [
                 '_id' => 1, 
                 'throughput' => ['$sum' => 1],
                 'latency' => ['$avg' => '$latency'],
+                'execution_time' => ['$avg' => '$execution_time'],
             ]],
         ]);
         if (!$document['ok']) {
@@ -118,6 +125,9 @@ class Repository
             ],
             'latency' => [
                 'average' => $averageLatency,
+            ],
+            'execution_time' => [
+                'average' => $averageExecutionTime,
             ],
         ];        
     }

--- a/src/Recruiter/Job/Repository.php
+++ b/src/Recruiter/Job/Repository.php
@@ -71,11 +71,15 @@ class Repository
         return $this->archived->count();
     }
 
-    public function queued()
+    public function queued($tag = null)
     {
-        return $this->scheduled->count([
+        $query = [
             'scheduled_at' => ['$lte' => T\MongoDate::now()],
-        ]);
+        ];
+        if ($tag !== null) {
+            $query['tags'] = $tag;
+        }
+        return $this->scheduled->count($query);
     }
 
     private function map($cursor)

--- a/src/Recruiter/Job/Repository.php
+++ b/src/Recruiter/Job/Repository.php
@@ -72,10 +72,13 @@ class Repository
         return $this->archived->count();
     }
 
-    public function queued($tag = null)
+    public function queued($tag = null, T\Moment $at = null)
     {
+        if ($at === null) {
+            $at = T\now();
+        }
         $query = [
-            'scheduled_at' => ['$lte' => T\MongoDate::now()],
+            'scheduled_at' => ['$lte' => T\MongoDate::from($at)],
         ];
         if ($tag !== null) {
             $query['tags'] = $tag;
@@ -83,12 +86,15 @@ class Repository
         return $this->scheduled->count($query);
     }
 
-    public function recentHistory($tag = null)
+    public function recentHistory($tag = null, T\Moment $at = null)
     {
+        if ($at === null) {
+            $at = T\now();
+        }
         $lastMinute = [
             'last_execution.ended_at' => [
-                '$gt' => T\MongoDate::from(T\now()->before(T\minute(1))),
-                '$lte' => T\MongoDate::from(T\now())
+                '$gt' => T\MongoDate::from($at->before(T\minute(1))),
+                '$lte' => T\MongoDate::from($at)
             ],
         ];
         if ($tag !== null) {

--- a/src/Recruiter/JobExecution.php
+++ b/src/Recruiter/JobExecution.php
@@ -7,13 +7,15 @@ use Exception;
 
 class JobExecution
 {
+    private $scheduledAt;
     private $startedAt;
     private $endedAt;
     private $completedWith;
     private $failedWith;
 
-    public function started()
+    public function started($scheduledAt = null)
     {
+        $this->scheduledAt = $scheduledAt;
         $this->startedAt = T\now();
     }
 
@@ -38,21 +40,28 @@ class JobExecution
     {
         $exported = [];
         if ($this->startedAt) {
-            $exported['started_at'] = T\MongoDate::from($this->startedAt);
-            if ($this->endedAt) {
-                $exported['ended_at'] = T\MongoDate::from($this->endedAt);
-                if ($this->failedWith) {
-                    $exported['class'] = get_class($this->failedWith);
-                    $exported['message'] = $this->failedWith->getMessage();
-                    $exported['trace'] = $this->traceOf($this->completedWith);
-                }
-                if ($this->completedWith) {
-                    $exported['trace'] = $this->traceOf($this->completedWith);
-                }
-            }
-            return ['last_execution' => $exported];
+            $exported['scheduled_at'] = T\MongoDate::from($this->scheduledAt);
         }
-        return $exported;
+        if ($this->startedAt) {
+            $exported['started_at'] = T\MongoDate::from($this->startedAt);
+        }
+        if ($this->endedAt) {
+            $exported['ended_at'] = T\MongoDate::from($this->endedAt);
+        }
+        if ($this->failedWith) {
+            $exported['class'] = get_class($this->failedWith);
+            $exported['message'] = $this->failedWith->getMessage();
+            $exported['trace'] = $this->traceOf($this->completedWith);
+        }
+        if ($this->completedWith) {
+            $exported['trace'] = $this->traceOf($this->completedWith);
+        }
+
+        if ($exported) {
+            return ['last_execution' => $exported];
+        } else {
+            return [];
+        }
     }
 
     private function traceOf($result)

--- a/src/Recruiter/Recruiter.php
+++ b/src/Recruiter/Recruiter.php
@@ -41,6 +41,21 @@ class Recruiter
         );
     }
 
+    public function queued()
+    {
+        return $this->jobs->queued();
+    }
+
+    public function statistics()
+    {
+        return array_merge(
+            [
+                'queued' => $this->jobs->queued(),
+            ],
+            $this->jobs->recentHistory()
+        );
+    }
+
     public function ensureIsTheOnlyOne(Interval $timeToWaitAtMost, $otherwise)
     {
         try {

--- a/src/Recruiter/Recruiter.php
+++ b/src/Recruiter/Recruiter.php
@@ -46,13 +46,13 @@ class Recruiter
         return $this->jobs->queued();
     }
 
-    public function statistics()
+    public function statistics($tag = null)
     {
         return array_merge(
             [
-                'queued' => $this->jobs->queued(),
+                'queued' => $this->jobs->queued($tag),
             ],
-            $this->jobs->recentHistory()
+            $this->jobs->recentHistory($tag)
         );
     }
 

--- a/src/Recruiter/Recruiter.php
+++ b/src/Recruiter/Recruiter.php
@@ -164,6 +164,9 @@ class Recruiter
         $this->db->selectCollection('archived')->ensureIndex([
             'created_at' => 1,
         ]);
+        $this->db->selectCollection('archived')->ensureIndex([
+            'last_execution.ended_at' => 1,
+        ]);
 
         $this->db->command(['collMod' => 'roster', 'usePowerOf2Sizes' => true]);
         $this->db->selectCollection('roster')->ensureIndex([

--- a/src/Recruiter/Recruiter.php
+++ b/src/Recruiter/Recruiter.php
@@ -4,6 +4,7 @@ namespace Recruiter;
 
 use MongoDB;
 use Timeless\Interval;
+use Timeless\Moment;
 
 use Onebip\Clock;
 use Onebip\Concurrency\MongoLock;
@@ -46,13 +47,13 @@ class Recruiter
         return $this->jobs->queued();
     }
 
-    public function statistics($tag = null)
+    public function statistics($tag = null, Moment $at = null)
     {
         return array_merge(
             [
-                'queued' => $this->jobs->queued($tag),
+                'queued' => $this->jobs->queued($tag, $at),
             ],
-            $this->jobs->recentHistory($tag)
+            $this->jobs->recentHistory($tag, $at)
         );
     }
 

--- a/src/Timeless/MongoDate.php
+++ b/src/Timeless/MongoDate.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Timeless;
 
 class MongoDate
@@ -10,6 +9,15 @@ class MongoDate
         $milliseconds = $moment->ms() - $seconds * 1000;
         $microseconds = $milliseconds * 1000;
         return new \MongoDate($seconds, $microseconds);
+    }
+
+    /**
+     * @return Moment
+     */
+    public static function toMoment(\MongoDate $mongoDate)
+    {
+        $milliseconds = $mongoDate->sec * 1000 + round($mongoDate->usec / 1000);
+        return new Moment($milliseconds);
     }
 
     public static function now()


### PR DESCRIPTION
Statistics that can be gathered:
- `queued`: how many jobs are scheduled to be executed before now
- `throughput` (per minute and per second): how many jobs were executed per unit of time
- `latency`: the average time between scheduling a job and starting its execution
- `execution_time`: the average time between starting a job and completing it (with success or failure)

All averages are calculated over the last 60 seconds, and can be filtered by tag.
