### PR TITLE
Passing retry statistics to each Workable

### DIFF
--- a/spec/Recruiter/JobTest.php
+++ b/spec/Recruiter/JobTest.php
@@ -1,0 +1,51 @@
+<?php
+namespace Recruiter;
+
+use Recruiter\Workable\AlwaysFail;
+
+class JobTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->repository = $this
+            ->getMockBuilder('Recruiter\Job\Repository')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testRetryStatisticsOnFirstExecution()
+    {
+        $job = Job::around(new AlwaysFail, $this->repository);
+        $retryStatistics = $job->retryStatistics();
+        $this->assertInternalType('array', $retryStatistics);
+        $this->assertArrayHasKey('job_id', $retryStatistics);
+        $this->assertInternalType('string', $retryStatistics['job_id']);
+        $this->assertArrayHasKey('retry_number', $retryStatistics);
+        $this->assertEquals(0, $retryStatistics['retry_number']);
+        $this->assertArrayHasKey('last_execution', $retryStatistics);
+        $this->assertNull($retryStatistics['last_execution']);
+    }
+
+    /**
+     * @depends testRetryStatisticsOnFirstExecution
+     */
+    public function testRetryStatisticsOnSubsequentExecutions()
+    {
+        $job = Job::around(new AlwaysFail, $this->repository);
+        // maybe make the argument optional
+        $job->execute($this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
+        $job = Job::import($job->export(), $this->repository);
+        $retryStatistics = $job->retryStatistics();
+        $this->assertEquals(1, $retryStatistics['retry_number']);
+        $this->assertArrayHasKey('last_execution', $retryStatistics);
+        $lastExecution = $retryStatistics['last_execution'];
+        $this->assertInternalType('array', $lastExecution);
+        $this->assertArrayHasKey('started_at', $lastExecution);
+        $this->assertArrayHasKey('ended_at', $lastExecution);
+        $this->assertArrayHasKey('class', $lastExecution);
+        $this->assertArrayHasKey('message', $lastExecution);
+        $this->assertArrayHasKey('trace', $lastExecution);
+        $this->assertEquals("Sorry, I'm good for nothing", $lastExecution['message']);
+        $this->assertEquals("Sorry, I'm good for nothing", $lastExecution['trace']);
+    }
+}

--- a/spec/Recruiter/JobToBePassedRetryStatisticsTest.php
+++ b/spec/Recruiter/JobToBePassedRetryStatisticsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Recruiter;
+
+use Timeless as T;
+use Recruiter\RetryPolicy\DoNotDoItAgain;
+
+class JobToBePassedRetryStatisticsTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->repository = $this
+            ->getMockBuilder('Recruiter\Job\Repository')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testTakeRetryPolicyFromRetriableInstance()
+    {
+        $workable = new WorkableThatUsesRetryStatistics();
+
+        $job = Job::around($workable, $this->repository);
+        $job->execute($this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
+        $this->assertTrue($job->done(), "Job requiring retry statistics was not executed correctly: " . var_export($job->export(), true));
+    }
+}
+
+class WorkableThatUsesRetryStatistics implements Workable, Retriable
+{
+    use WorkableBehaviour;
+
+    public function retryWithPolicy()
+    {
+        return new DoNotDoItAgain();
+    }
+
+    public function execute(array $retryStatistics)
+    {
+    }
+}

--- a/spec/Recruiter/Workable/FactoryMethodCommandTest.php
+++ b/spec/Recruiter/Workable/FactoryMethodCommandTest.php
@@ -21,6 +21,14 @@ class FactoryMethodCommandTest extends \PHPUnit_Framework_TestCase
             FactoryMethodCommand::import($workable->export())
         );
     }
+
+    public function testPassesRetryStatisticsAsAnAdditionalArgumentToTheLastMethodToCall()
+    {
+        $workable = FactoryMethodCommand::from('Recruiter\Workable\DummyFactory::create')
+            ->myObject()
+            ->myNeedyMethod();
+        $workable->execute(['retry_number' => 0]);
+    }
 }
 
 class DummyFactory
@@ -39,6 +47,11 @@ class DummyFactory
 class DummyObject
 {
     public function myMethod($what, $value)
+    {
+        return $value;
+    }
+
+    public function myNeedyMethod(array $retryStatistics)
     {
         return $value;
     }

--- a/src/Recruiter/Job.php
+++ b/src/Recruiter/Job.php
@@ -105,11 +105,11 @@ class Job
         }
     }
 
-    private function retryStatistics()
+    public function retryStatistics()
     {
         return [
             'job_id' => (string) $this->id(),
-            'retry_number' => $this->status['attempts'] - 1,
+            'retry_number' => $this->status['attempts'],
             'last_execution' => $this->status['last_execution'],
         ];
     }

--- a/src/Recruiter/JobExecution.php
+++ b/src/Recruiter/JobExecution.php
@@ -51,7 +51,7 @@ class JobExecution
         if ($this->failedWith) {
             $exported['class'] = get_class($this->failedWith);
             $exported['message'] = $this->failedWith->getMessage();
-            $exported['trace'] = $this->traceOf($this->completedWith);
+            $exported['trace'] = $this->traceOf($this->failedWith);
         }
         if ($this->completedWith) {
             $exported['trace'] = $this->traceOf($this->completedWith);

--- a/src/Recruiter/Workable/FactoryMethodCommand.php
+++ b/src/Recruiter/Workable/FactoryMethodCommand.php
@@ -50,7 +50,8 @@ class FactoryMethodCommand implements Workable
     public function execute($retryOptions = null)
     {
         $result = null;
-        foreach ($this->steps as $step) {
+        $lastStepIndex = count($this->steps) - 1;
+        foreach ($this->steps as $index => $step) {
             if (isset($step['class'])) {
                 $callable = $step['class'] . '::' . $step['method'];
             } else {
@@ -66,6 +67,9 @@ class FactoryMethodCommand implements Workable
                 throw new \BadMethodCallException($message);
             }
             $arguments = $this->arguments($step);
+            if ($index === $lastStepIndex) {
+                $arguments[] = $retryOptions;
+            }
             $result = call_user_func_array(
                 $callable,
                 $arguments

--- a/src/Recruiter/Workable/LazyBones.php
+++ b/src/Recruiter/Workable/LazyBones.php
@@ -23,7 +23,7 @@ class LazyBones implements Workable
         return new self($timeInMs * 1000, $deltaInMs * 1000);
     }
 
-    public function __construct($usToSleep, $usOfDelta)
+    public function __construct($usToSleep = 1, $usOfDelta = 0)
     {
         $this->usToSleep = $usToSleep;
         $this->usOfDelta = $usOfDelta;


### PR DESCRIPTION
They can be used, for example, to determine if a billing is on the last retry and should trigger a `failed` Delivery Report instead of a ShortRetryException.