### PR TITLE
Allowing only one `tag` (renamed in `group`) in place of multiple tags

### DIFF
--- a/src/Recruiter/Job.php
+++ b/src/Recruiter/Job.php
@@ -75,6 +75,7 @@ class Job
     {
         if (!empty($tags)) {
             $this->status['tags'] = $tags;
+            $this->status['group'] = $tags[0];
         }
 
         return $this;
@@ -203,6 +204,7 @@ class Job
                 'locked' => false,
                 'attempts' => 0,
                 'tags' => ['generic'],
+                'group' => 'generic',
             ],
             WorkableInJob::initialize(),
             RetryPolicyInJob::initialize()


### PR DESCRIPTION
We want to remove the feature which allows multiple tags
This commit support backward compatibility, we do not change job picking until production jobs have only `tags` field.
The new field name will be group.