### PR TITLE
Increasing mongodb safety

### DIFF
--- a/bin/cleaner
+++ b/bin/cleaner
@@ -10,6 +10,7 @@ use Onebip\Concurrency\MongoLock;
 use Timeless\Interval;
 use Ulrichsg\Getopt\Getopt;
 use Ulrichsg\Getopt\Option;
+use Recruiter\MongoFactory;
 
 $defaultTarget = 'localhost:27017/recruiter';
 $options = [
@@ -28,7 +29,8 @@ $cliOptions = new Getopt($options);
 $cliOptions->parse();
 
 list($hosts, $dbName, $options) = parseMongoDSN($cliOptions['target']);
-$db = (new MongoClient($hosts, $options))->selectDb($dbName);
+$mongoFactory = new MongoFactory();
+$db = $mongoFactory->getMongoDb($hosts, $options, $dbName);
 
 $waitStrategy = new WaitStrategy(
     Interval::parse($cliOptions['wait-at-least']),

--- a/bin/loader
+++ b/bin/loader
@@ -5,6 +5,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Recruiter\Recruiter;
 use Recruiter\Workable\LazyBones;
+use Recruiter\MongoFactory;
 
 $howManyJobsInBatch = 100;
 $howManyJobsToKeepAsScheduled = 2000;
@@ -12,7 +13,12 @@ $howManyJobsToKeepAsScheduled = 2000;
 $pid = posix_getpid();
 $options = array_merge(['host' => 'localhost:27017'], getopt('', ['host:']));
 
-$db = (new MongoClient($options['host']))->selectDB('recruiter');
+$mongoFactory = new MongoFactory();
+$db = $mongoFactory->getMongoDb(
+    $options['host'],
+    $mongoDbOptions = [],
+    $dbName = 'recruiter'
+);
 $recruiter = new Recruiter($db);
 
 while(true) {

--- a/examples/jobAndWorkerTagged.php
+++ b/examples/jobAndWorkerTagged.php
@@ -4,10 +4,16 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Recruiter\Recruiter;
+use Recruiter\MongoFactory;
 use Recruiter\Workable\LazyBones;
 use Recruiter\Worker;
 
-$db = (new MongoClient())->selectDB('recruiter');
+$mongoFactory = new MongoFactory();
+$db = $mongoFactory->getMongoDb(
+    $hosts = 'localhost:27017',
+    $options = [],
+    $dbName = 'recruiter'
+);
 $db->drop();
 
 $recruiter = new Recruiter($db);

--- a/examples/jobFailedBecauseOfNonRetriableException.php
+++ b/examples/jobFailedBecauseOfNonRetriableException.php
@@ -6,11 +6,17 @@ require __DIR__ . '/../vendor/autoload.php';
 use Timeless as T;
 
 use Recruiter\Recruiter;
+use Recruiter\MongoFactory;
 use Recruiter\Workable\AlwaysFail;
 use Recruiter\RetryPolicy;
 use Recruiter\Worker;
 
-$db = (new MongoClient())->selectDB('recruiter');
+$mongoFactory = new MongoFactory();
+$db = $mongoFactory->getMongoDb(
+    $hosts = 'localhost:27017',
+    $options = [],
+    $dbName = 'recruiter'
+);
 $db->drop();
 
 $recruiter = new Recruiter($db);

--- a/examples/jobRetriedManyTimesUntilArchived.php
+++ b/examples/jobRetriedManyTimesUntilArchived.php
@@ -6,11 +6,17 @@ require __DIR__ . '/../vendor/autoload.php';
 use Timeless as T;
 
 use Recruiter\Recruiter;
+use Recruiter\MongoFactory;
 use Recruiter\Workable\AlwaysFail;
 use Recruiter\RetryPolicy;
 use Recruiter\Worker;
 
-$db = (new MongoClient())->selectDB('recruiter');
+$mongoFactory = new MongoFactory();
+$db = $mongoFactory->getMongoDb(
+    $hosts = 'localhost:27017',
+    $options = [],
+    $dbName = 'recruiter'
+);
 $db->drop();
 
 $recruiter = new Recruiter($db);

--- a/examples/oneTimeJob.php
+++ b/examples/oneTimeJob.php
@@ -4,10 +4,16 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Recruiter\Recruiter;
+use Recruiter\MongoFactory;
 use Recruiter\Workable\LazyBones;
 use Recruiter\Worker;
 
-$db = (new MongoClient())->selectDB('recruiter');
+$mongoFactory = new MongoFactory();
+$db = $mongoFactory->getMongoDb(
+    $hosts = 'localhost:27017',
+    $options = [],
+    $dbName = 'recruiter'
+);
 $db->drop();
 
 $recruiter = new Recruiter($db);

--- a/spec/Recruiter/Acceptance/BaseAcceptanceTest.php
+++ b/spec/Recruiter/Acceptance/BaseAcceptanceTest.php
@@ -2,15 +2,20 @@
 namespace Recruiter\Acceptance;
 
 use Recruiter\Recruiter;
+use Recruiter\MongoFactory;
 use Recruiter\Workable\ShellCommand;
-use MongoClient;
 use Onebip\Concurrency\Timeout;
 
 abstract class BaseAcceptanceTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->recruiterDb = (new MongoClient('localhost:27017'))->selectDB('recruiter');
+        $mongoFactory = new MongoFactory();
+        $this->recruiterDb = $mongoFactory->getMongoDb(
+            $hosts = 'localhost:27017',
+            $options = [],
+            $dbName = 'recruiter'
+        );
         $this->cleanDb();
         $this->files = ['/tmp/recruiter.log', '/tmp/worker.log'];
         $this->cleanLogs();

--- a/spec/Recruiter/Job/RepositoryTest.php
+++ b/spec/Recruiter/Job/RepositoryTest.php
@@ -2,8 +2,8 @@
 namespace Recruiter\Job;
 
 use Recruiter\Job;
+use Recruiter\MongoFactory;
 use Recruiter\JobToSchedule;
-use MongoClient;
 use DateTime;
 use Timeless as T;
 
@@ -11,7 +11,12 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->recruiterDb = (new MongoClient('localhost:27017'))->selectDB('recruiter');
+        $mongoFactory = new MongoFactory();
+        $this->recruiterDb = $mongoFactory->getMongoDb(
+            $hosts = 'localhost:27017',
+            $options = [],
+            $dbName = 'recruiter'
+        );
         $this->recruiterDb->drop();
         $this->repository = new Repository($this->recruiterDb);
         $this->clock = T\clock()->stop();

--- a/spec/Recruiter/MongoFactoryTest.php
+++ b/spec/Recruiter/MongoFactoryTest.php
@@ -6,15 +6,30 @@ use MongoDB;
 
 class MongoFactoryTest extends \PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        $this->mongoFactory = new MongoFactory();
+    }
+
     public function testShouldCreateAMongoDatabaseConnection()
     {
-        $mongoFactory = new MongoFactory();
         $this->assertInstanceOf(
             'MongoDB',
-            $mongoFactory->getMongoDb(
+            $this->mongoFactory->getMongoDb(
                 $host = 'localhost:27017',
                 $options = ['connectTimeoutMS' => '1000'],
                 $dbName = 'recruiter'
         ));
+    }
+
+    public function testWriteConcernIsMajorityByDefault()
+    {
+        $mongoDb = $this->mongoFactory->getMongoDb(
+                $host = 'localhost:27017',
+                $options = ['connectTimeoutMS' => '1000'],
+                $dbName = 'recruiter'
+        );
+
+        $this->assertEquals('majority', $mongoDb->getWriteConcern()['w']);
     }
 }

--- a/spec/Recruiter/MongoFactoryTest.php
+++ b/spec/Recruiter/MongoFactoryTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Recruiter;
+
+use MongoDB;
+
+class MongoFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldCreateAMongoDatabaseConnection()
+    {
+        $mongoFactory = new MongoFactory();
+        $this->assertInstanceOf(
+            'MongoDB',
+            $mongoFactory->getMongoDb(
+                $host = 'localhost:27017',
+                $options = ['connectTimeoutMS' => '1000'],
+                $dbName = 'recruiter'
+        ));
+    }
+}

--- a/spec/Recruiter/MongoFactoryTest.php
+++ b/spec/Recruiter/MongoFactoryTest.php
@@ -9,27 +9,44 @@ class MongoFactoryTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->mongoFactory = new MongoFactory();
+        $this->dbHost = 'localhost:27017';
+        $this->dbName = 'recruiter';
     }
 
     public function testShouldCreateAMongoDatabaseConnection()
     {
         $this->assertInstanceOf(
             'MongoDB',
-            $this->mongoFactory->getMongoDb(
-                $host = 'localhost:27017',
-                $options = ['connectTimeoutMS' => '1000'],
-                $dbName = 'recruiter'
-        ));
+            $this->creationOfDefaultMongoDb()
+        );
     }
 
     public function testWriteConcernIsMajorityByDefault()
     {
+        $mongoDb = $this->creationOfDefaultMongoDb();
+        $this->assertEquals('majority', $mongoDb->getWriteConcern()['w']);
+    }
+
+    public function testShouldOverwriteTheWriteConcernPassedInTheOptions()
+    {
         $mongoDb = $this->mongoFactory->getMongoDb(
                 $host = 'localhost:27017',
-                $options = ['connectTimeoutMS' => '1000'],
+                $options = [
+                    'connectTimeoutMS' => '1000',
+                    'w' => '0',
+                ],
                 $dbName = 'recruiter'
         );
 
         $this->assertEquals('majority', $mongoDb->getWriteConcern()['w']);
+    }
+
+    private function creationOfDefaultMongoDb()
+    {
+        return $this->mongoFactory->getMongoDb(
+             $host = $this->dbHost,
+             $options = ['connectTimeoutMS' => '1000'],
+             $dbName = $this->dbName
+        );
     }
 }

--- a/src/MongoFactory.php
+++ b/src/MongoFactory.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Recruiter;
-
-class MongoFactory
-{
-
-}

--- a/src/MongoFactory.php
+++ b/src/MongoFactory.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Recruiter;
+
+class MongoFactory
+{
+
+}

--- a/src/Recruiter/MongoFactory.php
+++ b/src/Recruiter/MongoFactory.php
@@ -8,6 +8,7 @@ class MongoFactory
 {
     public function getMongoDb($hosts, $options, $dbName)
     {
-        return $db = (new MongoClient($hosts, $options))->selectDb($dbName);
+        $optionsWithMajorityConcern = array_merge($options, ['w' => 'majority']);
+        return $db = (new MongoClient($hosts, $optionsWithMajorityConcern))->selectDb($dbName);
     }
 }

--- a/src/Recruiter/MongoFactory.php
+++ b/src/Recruiter/MongoFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Recruiter;
+
+use MongoClient;
+
+class MongoFactory
+{
+    public function getMongoDb($hosts, $options, $dbName)
+    {
+        return $db = (new MongoClient($hosts, $options))->selectDb($dbName);
+    }
+}

--- a/src/Recruiter/Option/TargetHost.php
+++ b/src/Recruiter/Option/TargetHost.php
@@ -2,10 +2,9 @@
 namespace Recruiter\Option;
 
 use Recruiter;
+use Recruiter\MongoFactory;
 use Ulrichsg\Getopt;
 use UnexpectedValueException;
-
-use MongoClient;
 use MongoConnectionException;
 
 class TargetHost implements Recruiter\Option
@@ -26,6 +25,7 @@ class TargetHost implements Recruiter\Option
             $this->defaultHost . ':' .
             $this->defaultPort . '/' .
             $this->defaultDb;
+        $this->mongoFactory = new MongoFactory();
     }
 
     public function specification()
@@ -49,11 +49,8 @@ class TargetHost implements Recruiter\Option
     private function validate($target)
     {
         try {
-            list($hosts, $db, $options) = $this->parse($target ?: $this->defaultTarget);
-            return (new MongoClient(
-                $hosts,
-                $options
-            ))->selectDB($db);
+            list($hosts, $dbName, $options) = $this->parse($target ?: $this->defaultTarget);
+            return $this->mongoFactory->getMongoDb($hosts, $options, $dbName);
         } catch(MongoConnectionException $e) {
             throw new UnexpectedValueException(
                 sprintf(


### PR DESCRIPTION
We have created a Factory to force the `w` option of the MongoClient to `majority`.

The default `w` is `1` and in case of failover there is the possibility that the new `PRIMARY` does not have the writes of the previous one. This is a potential issue for our queue engine so we force `w=majority` everywhere.