### PR TITLE
avoding race condition when woker dies

### DIFF
--- a/bin/worker
+++ b/bin/worker
@@ -30,7 +30,7 @@ foreach ([SIGTERM, SIGQUIT, SIGINT] as $signal) {
     });
 }
 
-$worker = $filterJobToWorkOn->applyTo($recruiter->hire());
+$worker = $filterJobToWorkOn->applyTo($recruiter->hire($memoryLimit));
 
 printf('[WORKER][%d][%s] worker %s ready to work!' . PHP_EOL, posix_getpid(), date('c'), $worker->id());
 while (true) {
@@ -44,7 +44,6 @@ while (true) {
         }
     }
     $doneSomeWork = $worker->work();
-    $memoryLimit->ensure(memory_get_usage());
     if ($doneSomeWork) {
         printf(
             '[WORKER][%d][%s] executed job %s' . PHP_EOL,

--- a/examples/jobAndWorkerTagged.php
+++ b/examples/jobAndWorkerTagged.php
@@ -7,6 +7,7 @@ use Recruiter\Recruiter;
 use Recruiter\Factory;
 use Recruiter\Workable\LazyBones;
 use Recruiter\Worker;
+use Recruiter\Option\MemoryLimit;
 
 $factory = new Factory();
 $db = $factory->getMongoDb(
@@ -24,7 +25,8 @@ LazyBones::waitForMs(200, 100)
     ->inBackground()
     ->execute();
 
-$worker = $recruiter->hire();
+$memoryLimit = new MemoryLimit('memory-limit', '64MB');
+$worker = $recruiter->hire($memoryLimit);
 $worker->workOnJobsGroupedAs('mail');
 $assignments = $recruiter->assignJobsToWorkers();
 $worker->work();

--- a/examples/jobFailedBecauseOfNonRetriableException.php
+++ b/examples/jobFailedBecauseOfNonRetriableException.php
@@ -10,6 +10,7 @@ use Recruiter\Factory;
 use Recruiter\Workable\AlwaysFail;
 use Recruiter\RetryPolicy;
 use Recruiter\Worker;
+use Recruiter\Option\MemoryLimit;
 
 $factory = new Factory();
 $db = $factory->getMongoDb(
@@ -27,7 +28,8 @@ $recruiter = new Recruiter($db);
     ->inBackground()
     ->execute();
 
-$worker = $recruiter->hire();
+$memoryLimit = new MemoryLimit('memory-limit', '64MB');
+$worker = $recruiter->hire($memoryLimit);
 while (true) {
     printf("Try to do my work\n");
     $assignments = $recruiter->assignJobsToWorkers();

--- a/examples/jobRetriedManyTimesUntilArchived.php
+++ b/examples/jobRetriedManyTimesUntilArchived.php
@@ -10,6 +10,7 @@ use Recruiter\Factory;
 use Recruiter\Workable\AlwaysFail;
 use Recruiter\RetryPolicy;
 use Recruiter\Worker;
+use Recruiter\Option\MemoryLimit;
 
 $factory = new Factory();
 $db = $factory->getMongoDb(
@@ -27,7 +28,8 @@ $recruiter = new Recruiter($db);
     ->inBackground()
     ->execute();
 
-$worker = $recruiter->hire();
+$memoryLimit = new MemoryLimit('memory-limit', '64MB');
+$worker = $recruiter->hire($memoryLimit);
 while (true) {
     printf("Try to do my work\n");
     $assignments = $recruiter->assignJobsToWorkers();

--- a/examples/oneTimeJob.php
+++ b/examples/oneTimeJob.php
@@ -7,6 +7,7 @@ use Recruiter\Recruiter;
 use Recruiter\Factory;
 use Recruiter\Workable\LazyBones;
 use Recruiter\Worker;
+use Recruiter\Option\MemoryLimit;
 
 $factory = new Factory();
 $db = $factory->getMongoDb(
@@ -23,6 +24,7 @@ LazyBones::waitForMs(200, 100)
     ->inBackground()
     ->execute();
 
-$worker = $recruiter->hire();
+$memoryLimit = new MemoryLimit('memory-limit', '64MB');
+$worker = $recruiter->hire($memoryLimit);
 $assignments = $recruiter->assignJobsToWorkers();
 $worker->work();

--- a/spec/Recruiter/Acceptance/AssignmentTest.php
+++ b/spec/Recruiter/Acceptance/AssignmentTest.php
@@ -2,17 +2,19 @@
 namespace Recruiter\Acceptance;
 
 use Recruiter\Workable\LazyBones;
+use Recruiter\Option\MemoryLimit;
 
 class AssignmentTest extends BaseAcceptanceTest
 {
     public function testAJobCanBeAssignedAndExecuted()
     {
+        $memoryLimit = new MemoryLimit('memory-limit', '64MB');
         LazyBones::waitForMs(200, 100)
             ->asJobOf($this->recruiter)
             ->inBackground()
             ->execute();
 
-        $worker = $this->recruiter->hire();
+        $worker = $this->recruiter->hire($memoryLimit);
         list ($assignments, $totalNumber) = $this->recruiter->assignJobsToWorkers();
         $this->assertEquals(1, count($assignments));
         $this->assertEquals(1, $totalNumber);

--- a/spec/Recruiter/Acceptance/FaultToleranceTest.php
+++ b/spec/Recruiter/Acceptance/FaultToleranceTest.php
@@ -1,13 +1,15 @@
 <?php
 namespace Recruiter\Acceptance;
 
+use Recruiter\Option\MemoryLimit;
 
 class FaultToleranceTest extends BaseAcceptanceTest
 {
     public function testRecruiterCrashAfterLockingJobsBeforeAssignmentAndIsRestarted()
     {
+        $memoryLimit = new MemoryLimit('memory-limit', '64MB');
         $this->enqueueJob();
-        $worker = $this->recruiter->hire();
+        $worker = $this->recruiter->hire($memoryLimit);
 
         $assignments = $this->recruiter->bookJobsForWorkers();
 

--- a/spec/Recruiter/Acceptance/HooksTest.php
+++ b/spec/Recruiter/Acceptance/HooksTest.php
@@ -3,10 +3,17 @@ namespace Recruiter\Acceptance;
 
 use Recruiter\Workable\AlwaysFail;
 use Recruiter\Workable\AlwaysSucceed;
+use Recruiter\Option\MemoryLimit;
 use Symfony\Component\EventDispatcher\Event;
 
 class HooksTest extends BaseAcceptanceTest
 {
+    public function setUp()
+    {
+        $this->memoryLimit = new MemoryLimit('memory-limit', '64MB');
+        parent::setUp();
+    }
+
     public function testAfterLastFailureEventIsFired()
     {
         $this->events = [];
@@ -23,7 +30,7 @@ class HooksTest extends BaseAcceptanceTest
             ->inBackground()
             ->execute();
 
-        $worker = $this->recruiter->hire();
+        $worker = $this->recruiter->hire($this->memoryLimit);
         $this->recruiter->assignJobsToWorkers();
         $worker->work();
 
@@ -48,7 +55,7 @@ class HooksTest extends BaseAcceptanceTest
             ->inBackground()
             ->execute();
 
-        $worker = $this->recruiter->hire();
+        $worker = $this->recruiter->hire($this->memoryLimit);
         $this->recruiter->assignJobsToWorkers();
         $worker->work();
 
@@ -77,7 +84,7 @@ class HooksTest extends BaseAcceptanceTest
             ->inBackground()
             ->execute();
 
-        $worker = $this->recruiter->hire();
+        $worker = $this->recruiter->hire($this->memoryLimit);
         $this->recruiter->assignJobsToWorkers();
         $worker->work();
         $this->recruiter->assignJobsToWorkers();

--- a/spec/Recruiter/Option/MemoryLimitTest.php
+++ b/spec/Recruiter/Option/MemoryLimitTest.php
@@ -1,0 +1,14 @@
+<?php
+namespace Recruiter\Option;
+
+class MemoryLimitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Recruiter\Option\MemoryLimitExceededException
+     */
+    public function testThrowsAnExceptionWhenMemoryLimitIsExceeded()
+    {
+        $memoryLimit = new MemoryLimit('test', 1);
+        $memoryLimit->ensure(2);
+    }
+}

--- a/src/Recruiter/Option/MemoryLimit.php
+++ b/src/Recruiter/Option/MemoryLimit.php
@@ -41,12 +41,10 @@ class MemoryLimit implements Recruiter\Option
     {
         $used = ByteUnits\box($used);
         if ($used->isGreaterThan($this->limit)) {
-            fprintf(STDERR,
-                'Memory limit reached, %s is more than the force limit of %s' . PHP_EOL,
+            throw new MemoryLimitExceededException(sprintf(
+                'Memory limit reached, %s is more than the force limit of %s',
                 $used->format(), $this->limit->format()
-            );
-            // TODO: avoid exit(1) and try to perform a graceful shutdown
-            exit(1);
+            ));
         }
     }
 

--- a/src/Recruiter/Option/MemoryLimitExceededException.php
+++ b/src/Recruiter/Option/MemoryLimitExceededException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Recruiter\Option;
+
+class MemoryLimitExceededException extends \Exception
+{
+
+}

--- a/src/Recruiter/Recruiter.php
+++ b/src/Recruiter/Recruiter.php
@@ -1,11 +1,11 @@
 <?php
-
 namespace Recruiter;
 
 use MongoDB;
 use Timeless\Interval;
 use Timeless\Moment;
 use Timeless as T;
+use Recruiter\Option\MemoryLimit;
 
 use Onebip\Clock;
 use Onebip\Concurrency\MongoLock;
@@ -34,9 +34,9 @@ class Recruiter
         $this->eventDispatcher = new EventDispatcher();
     }
 
-    public function hire()
+    public function hire(MemoryLimit $memoryLimit)
     {
-        return Worker::workFor($this, $this->workers);
+        return Worker::workFor($this, $this->workers, $memoryLimit);
     }
 
     public function jobOf(Workable $workable)


### PR DESCRIPTION
Moved memory limit check into `afterExecutionOf` to avoid unlocking the worker before killing it